### PR TITLE
Move animation control from `DragonBonesArmature` to `DragonBones`.

### DIFF
--- a/build_version.py
+++ b/build_version.py
@@ -1,6 +1,6 @@
 #!/usr/bin/env python
 import sys
 
-version = "v0.2.5-dev"
+version = "v1.0.0-dev"
 
 print("BUILD_VERSION=" + version)

--- a/demo/dragonbones_demo/demo.gd
+++ b/demo/dragonbones_demo/demo.gd
@@ -18,7 +18,7 @@ func _ready() -> void:
 
 	animation_process_mode_option_btn.item_selected.connect(_on_process_mode_option_btn_item_selected)
 	for idx in range(animation_process_mode_option_btn.item_count):
-		if animation_process_mode_option_btn.get_item_metadata(idx) == DragonBonesArmature.ANIMATION_CALLBACK_MODE_PROCESS_IDLE:
+		if animation_process_mode_option_btn.get_item_metadata(idx) == DragonBones.ANIMATION_CALLBACK_MODE_PROCESS_IDLE:
 			animation_process_mode_option_btn.select(idx)
 			_on_process_mode_option_btn_item_selected(idx)
 			break
@@ -45,19 +45,19 @@ func _ready() -> void:
 	%DebugCheck.button_pressed = false
 
 	# Active
-	%ActiveCheck.toggled.connect(func(toggled: bool): _armature.active = toggled)
-	%ActiveCheck.button_pressed = true
+	%ActiveCheck.toggled.connect(func(toggled: bool): dragonbones.active = toggled)
+	%ActiveCheck.button_pressed = false
 
 	# Time Scale
-	%TimeScaleSpinBox.value_changed.connect(func(value: float): _armature.time_scale = value)
+	%TimeScaleSpinBox.value_changed.connect(func(value: float): dragonbones.time_scale = value)
 	%TimeScaleSpinBox.value = 1.0
 	
 	# Manual Advance
 	%AdvanceBtn.pressed.connect(_on_advance_btn_pressed)
 
 func _on_process_mode_option_btn_item_selected(index: int) -> void:
-	_armature.callback_mode_process = animation_process_mode_option_btn.get_item_metadata(index)
-	%AdvanceUI.visible = _armature.callback_mode_process == DragonBonesArmature.ANIMATION_CALLBACK_MODE_PROCESS_MANUAL
+	dragonbones.callback_mode_process = animation_process_mode_option_btn.get_item_metadata(index)
+	%AdvanceUI.visible = dragonbones.callback_mode_process == DragonBones.ANIMATION_CALLBACK_MODE_PROCESS_MANUAL
 
 
 func _on_animation_option_btn_item_selected(index: int) -> void:
@@ -68,10 +68,11 @@ func _on_animation_option_btn_item_selected(index: int) -> void:
 	_armature.stop(_armature.current_animation, true)
 	if not anim.is_empty():
 		_armature.play(anim, -1)
+		#dragonbones.play()
 
 
 func _on_advance_btn_pressed() -> void:
-	assert(_armature.callback_mode_process == DragonBonesArmature.ANIMATION_CALLBACK_MODE_PROCESS_MANUAL)
+	assert(dragonbones.callback_mode_process == DragonBones.ANIMATION_CALLBACK_MODE_PROCESS_MANUAL)
 	var delta :float = %AdvanceTime.value
-	_armature.advance(delta)
+	dragonbones.advance(delta)
 	

--- a/src/dragonbones.h
+++ b/src/dragonbones.h
@@ -20,13 +20,18 @@ public:
 		dispatch_sound_event(to_gd_str(type), value);
 	}
 
+	enum AnimationCallbackModeProcess {
+		ANIMATION_CALLBACK_MODE_PROCESS_PHYSICS = 0,
+		ANIMATION_CALLBACK_MODE_PROCESS_IDLE = 1,
+		ANIMATION_CALLBACK_MODE_PROCESS_MANUAL = 2,
+	};
+
 private:
 	dragonBones::DragonBones *p_instance{ nullptr };
 
 	Ref<DragonBonesFactory> m_res;
-	String str_curr_anim{ "[none]" };
 	DragonBonesArmature *p_armature{ nullptr };
-	DragonBonesArmature::AnimationCallbackModeProcess callback_mode_process{ DragonBonesArmature::ANIMATION_CALLBACK_MODE_PROCESS_IDLE };
+	AnimationCallbackModeProcess callback_mode_process{ ANIMATION_CALLBACK_MODE_PROCESS_IDLE };
 	String instantiate_dragon_bones_data_name{ "" };
 	String instantiate_armature_name{ "" };
 	String instantiate_skin_name{ "" };
@@ -58,6 +63,8 @@ protected:
 #ifdef TOOLS_ENABLED
 	void _validate_property(PropertyInfo &p_property) const;
 #endif // TOOLS_ENABLED
+
+	void _notification(int p_what);
 
 public:
 	DragonBones();
@@ -94,8 +101,8 @@ public:
 	void set_instantiate_skin_name(String p_name);
 	String get_instantiate_skin_name() const;
 
-	void set_callback_mode_process(DragonBonesArmature::AnimationCallbackModeProcess _mode);
-	DragonBonesArmature::AnimationCallbackModeProcess get_callback_mode_process() const;
+	void set_callback_mode_process(AnimationCallbackModeProcess _mode);
+	AnimationCallbackModeProcess get_callback_mode_process() const;
 
 	int get_animation_loop() const;
 	void set_animation_loop(int p_animation_loop);
@@ -137,12 +144,12 @@ public:
 	/* deprecated */ void cycle_next_item_in_slot(const String &_slot_name);
 	/* deprecated */ void cycle_previous_item_in_slot(const String &_slot_name);
 	/* deprecated */ bool is_playing() const;
-	/* deprecated */ void play(bool _b_play = true);
 	/* deprecated */ void play_from_time(float _f_time);
 	/* deprecated */ void play_from_progress(float _f_progress);
 	/* deprecated */ void play_new_animation(const String &_str_anim, int _num_times);
 	/* deprecated */ void play_new_animation_from_progress(const String &_str_anim, int _num_times, float _f_progress);
 	/* deprecated */ void play_new_animation_from_time(const String &_str_anim, int _num_times, float _f_time);
+	/* deprecated */ void play();
 	/* deprecated */ void stop(bool _b_all = false);
 	/* deprecated */ inline void stop_all() { stop(true); }
 #endif
@@ -169,6 +176,7 @@ public:
 	}
 
 private:
+	void _set_process(bool p_process, bool p_force = false);
 	void _on_resource_changed();
 
 	void set_armature_settings(const Dictionary &p_settings) const;
@@ -217,3 +225,5 @@ public:
 };
 
 } //namespace godot
+
+VARIANT_ENUM_CAST(godot::DragonBones::AnimationCallbackModeProcess);

--- a/src/dragonbones_armature.h
+++ b/src/dragonbones_armature.h
@@ -14,12 +14,6 @@ namespace godot {
 class DragonBonesArmature : public GDDisplay, public dragonBones::IArmatureProxy {
 	GDCLASS(DragonBonesArmature, GDDisplay)
 public:
-	enum AnimationCallbackModeProcess {
-		ANIMATION_CALLBACK_MODE_PROCESS_PHYSICS = 0,
-		ANIMATION_CALLBACK_MODE_PROCESS_IDLE = 1,
-		ANIMATION_CALLBACK_MODE_PROCESS_MANUAL = 2,
-	};
-
 	enum AnimFadeOutMode {
 		FADE_OUT_NONE,
 		FADE_OUT_SAME_LAYER,
@@ -30,10 +24,9 @@ public:
 	};
 
 private:
-	AnimationCallbackModeProcess callback_mode_process{ ANIMATION_CALLBACK_MODE_PROCESS_IDLE };
-	bool active{ true };
-	bool processing{ false };
-	float time_scale{ 1.0f };
+	// bool active{ true };
+	// bool processing{ false };
+	// float time_scale{ 1.0f };
 
 	bool slots_inherit_material{ true };
 
@@ -200,14 +193,6 @@ public:
 	void set_debug(bool _b_debug, bool p_recursively = false);
 	bool is_debug() const { return b_debug; }
 
-	void set_active_(bool p_active) { set_active(p_active); }
-	void set_active(bool p_active, bool p_recursively = false);
-	bool is_active() const { return active; }
-
-	void set_callback_mode_process_(AnimationCallbackModeProcess p_process_mode) { set_callback_mode_process(p_process_mode); }
-	void set_callback_mode_process(AnimationCallbackModeProcess p_process_mode, bool p_recursively = false);
-	AnimationCallbackModeProcess get_callback_mode_process() const { return callback_mode_process; }
-
 	void set_flip_x_(bool p_flip_x) { set_flip_x(p_flip_x); }
 	void set_flip_x(bool p_flip_x, bool p_recursively = false);
 	bool is_flipped_x() const;
@@ -215,10 +200,6 @@ public:
 	void set_flip_y_(bool p_flip_y) { set_flip_y(p_flip_y); }
 	void set_flip_y(bool p_flip_y, bool p_recursively = false);
 	bool is_flipped_y() const;
-
-	void set_time_scale_(float p_time_scale) { set_time_scale(p_time_scale); }
-	void set_time_scale(float p_time_scale, bool p_recursively = false);
-	float get_time_scale() const;
 
 	Ref<Texture2D> get_texture_override() const;
 	void set_texture_override(const Ref<Texture2D> &p_texture_override);
@@ -235,8 +216,6 @@ public:
 #endif // TOOLS_ENABLED
 
 protected:
-	void _notification(int p_what);
-
 #ifdef TOOLS_ENABLED
 	struct StoragedProperty {
 		StringName name;
@@ -253,9 +232,6 @@ public:
 
 protected:
 #endif // TOOLS_ENABLED
-
-private:
-	void _set_process(bool p_process, bool p_force = false);
 };
 
 #ifdef TOOLS_ENABLED
@@ -285,5 +261,4 @@ private:
 
 } //namespace godot
 
-VARIANT_ENUM_CAST(godot::DragonBonesArmature::AnimationCallbackModeProcess);
 VARIANT_ENUM_CAST(godot::DragonBonesArmature::AnimFadeOutMode);


### PR DESCRIPTION
Fix [#21](https://github.com/Daylily-Zeleen/Godot-DragonBones/issues/21).

DragonBones event must dispatched by `dragonbones::DragonBones::advanceTime()`, I have to move animation control logic from `DragonBonesArmature` to `DragonBones`.

Now, armatures can not control animation by themselves, they can only set animation parameter, how and when to advance animation are controled by `DragonBones` node.

This commit have break changes, so will update major version.